### PR TITLE
Fixed charBuffer initialization

### DIFF
--- a/scripts/Display.cs
+++ b/scripts/Display.cs
@@ -20,7 +20,7 @@ public partial class Display : Node
 
 	private bool[,] displayBuffer;
 	private bool[,] displayBufferBuffer;
-	private string charBuffer;
+	private string charBuffer = "";
 	private int displayedNum = 0;
 	private bool unsigned = true;
 	public bool shouldRender = false;


### PR DESCRIPTION
When the following instruction is run with a fresh character buffer:

STR r0 r0 -8

The current code throws an ArgumentNullException in the PadWithUnderscores function, due the charBuffer being uninitialized (null). This causes the simulator to essentially freeze.

This pull request fixes charBuffer to its proper initialization - an empty string.